### PR TITLE
fix class definition

### DIFF
--- a/R/pt_classes.R
+++ b/R/pt_classes.R
@@ -35,8 +35,7 @@ setClass("ptable_params",
            optim=integer(),
            mono=logical(),
            pTableSize=integer(),
-           label=character(),
-           type=character()
+           label=character()
          ),
          validity=function(object) {
            stopifnot(is_integerish(object@D))
@@ -46,7 +45,7 @@ setClass("ptable_params",
            stopifnot(is_double(object@pstay))
            stopifnot(is_integerish(object@optim))
            stopifnot(is_logical(object@mono))
-           
+
 
            #stopifnot(all(object@mTable>0))
 


### PR DESCRIPTION
hi @tenderle 

checking the repo with r-dev complains about an inconsistent class-definition as you were using slot `type` in the prototype-part but not in the definition part of the class. 